### PR TITLE
Windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Afterwards (you may need to restart your shell first), use the `sd` (or `speeldo
     sd grep wohltemperirte
     sd init --composer="Johann Sebastian Bach" 48
 
+On Windows, I don't know yet.
+
 Usage
 -----
 Speeldoos consists of several subcommands, the most important of which are outlined below

--- a/cmd/speeldoos/cmd-seedvault.go
+++ b/cmd/speeldoos/cmd-seedvault.go
@@ -609,7 +609,6 @@ func (a *album) Job(dir string, fun jobFun) {
 			for cmdList := range cmds {
 				for _, toRun := range cmdList {
 					if cmd, ok := toRun.(*exec.Cmd); ok {
-						log.Printf("%s [%s]", cmd.Path, cmd.Args)
 						cmd.Stdout = os.Stdout
 						cmd.Stderr = os.Stderr
 						cmd.Start()

--- a/cmd/speeldoos/cmd-seedvault.go
+++ b/cmd/speeldoos/cmd-seedvault.go
@@ -391,7 +391,7 @@ func seedvault_main(argv []string) {
 		albus.Job(fmt.Sprintf("FLAC%d", last_bps), func(mf *mFile, wav, out string) []*exec.Cmd {
 			flac := out + ".flac"
 			return []*exec.Cmd{
-				exec.Command("flac", "-d", "-s", "-o", wav, flac),
+				exec.Command(Config.Tools.Flac, "-d", "-s", "-o", wav, flac),
 				metaflac(mf, flac),
 			}
 		})
@@ -402,8 +402,9 @@ func seedvault_main(argv []string) {
 		croak(os.MkdirAll(path.Join(Config.Seedvault.OutputDir, "wav"), 0755))
 		albus.Job("FLAC", func(mf *mFile, wav, out string) []*exec.Cmd {
 			flac := out + ".flac"
+			fmt.Printf("%s %s %s %s '%s' '%s'\n", Config.Tools.Flac, "-d", "-s", "-o", wav, flac)
 			return []*exec.Cmd{
-				exec.Command("flac", "-d", "-s", "-o", wav, flac),
+				exec.Command(Config.Tools.Flac, "-d", "-s", "-o", wav, flac),
 				metaflac(mf, flac),
 			}
 		})
@@ -681,7 +682,7 @@ func lameRun(extraArgs ...string) jobFun {
 		cmdline = append(cmdline, wav, mp3)
 
 		return []*exec.Cmd{
-			exec.Command("lame", cmdline...),
+			exec.Command(Config.Tools.Lame, cmdline...),
 			id3tags(s, mp3),
 		}
 	}
@@ -723,7 +724,7 @@ func id3tags(s *mFile, mp3 string) *exec.Cmd {
 }
 
 func metaflac(mm *mFile, flac string) *exec.Cmd {
-	cmd := exec.Command("metaflac", "--remove-all-tags", "--no-utf8-convert", "--import-tags-from=-", flac)
+	cmd := exec.Command(Config.Tools.Metaflac, "--remove-all-tags", "--no-utf8-convert", "--import-tags-from=-", flac)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cecinestpas, err := cmd.StdinPipe()
@@ -762,7 +763,7 @@ type bitness struct {
 }
 
 func (b *bitness) Check(file string) int {
-	cmd := exec.Command("metaflac", "--show-bps", file)
+	cmd := exec.Command(Config.Tools.Metaflac, "--show-bps", file)
 	cmd.Stderr = os.Stderr
 	cecinestpas, err := cmd.StdoutPipe()
 	croak(err)

--- a/cmd/speeldoos/cmd-seedvault.go
+++ b/cmd/speeldoos/cmd-seedvault.go
@@ -15,11 +15,23 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 )
 
 var zm = zipmap.New()
+
+var (
+	checkmark = "\u2713"
+)
+
+func init() {
+	// The '✓' glyph does not currently display correctly in PowerShell.
+	if runtime.GOOS == "windows" {
+		checkmark = "Y"
+	}
+}
 
 func confirmSettings() *speeldoos.Carrier {
 	fmt.Printf("\nAbout to start an encode with the following settings:\n")
@@ -227,7 +239,7 @@ func checkFileExists(filename string) string {
 	}
 
 	if zm.Exists(filename) {
-		return tc.Green("\u2713")
+		return tc.Green(checkmark)
 	}
 
 	return tc.Red("not found")

--- a/cmd/speeldoos/cmd-seedvault.go
+++ b/cmd/speeldoos/cmd-seedvault.go
@@ -83,7 +83,7 @@ func confirmSettings() *speeldoos.Carrier {
 	}
 
 	if Config.Seedvault.Tracker != "" {
-		fmt.Printf("\nURL to private tracker: %s\n", tc.Blue(Config.Seedvault.Tracker))
+		fmt.Printf("\nURL to private tracker: %s\n", tc.Bwhite(Config.Seedvault.Tracker))
 	}
 
 	fmt.Printf("\nEncodes to run: FLAC    %s\n", yes(true))

--- a/cmd/speeldoos/cmd-seedvault.go
+++ b/cmd/speeldoos/cmd-seedvault.go
@@ -720,7 +720,7 @@ func id3tags(s *mFile, mp3 string) *exec.Cmd {
 
 	args = append(args, mp3)
 
-	return exec.Command("id3v2", args...)
+	return exec.Command(Config.Tools.ID3v2, args...)
 }
 
 func metaflac(mm *mFile, flac string) *exec.Cmd {

--- a/cmd/speeldoos/cmd-seedvault.go
+++ b/cmd/speeldoos/cmd-seedvault.go
@@ -149,6 +149,9 @@ func (cp *commonPath) Add(disc int, sourcefile string) {
 
 func (cp *commonPath) FindOne(names ...string) (rv string, exists bool) {
 	for _, nn := range names {
+		if nn == "" {
+			continue
+		}
 		ss := cp.all
 		for ss != "." && ss != string(filepath.Separator) {
 			p := path.Join(ss, nn)
@@ -181,6 +184,9 @@ func (cp *commonPath) FindAllDiscs(names ...string) (string, bool) {
 }
 
 func (cp *commonPath) existsForEachDisc(dir, file string) bool {
+	if file == "" {
+		return false
+	}
 	for d, _ := range cp.discs {
 		sub := ""
 		if d > 0 {

--- a/cmd/speeldoos/speeldoos.go
+++ b/cmd/speeldoos/speeldoos.go
@@ -13,7 +13,11 @@ var Config = struct {
 	Subcommand     string
 	ConcurrentJobs int
 	LibraryDir     string
-	Extract        struct {
+	Tools          struct {
+		Flac, Metaflac string
+		Lame           string
+	}
+	Extract struct {
 		Bitrate string
 	}
 	Grep struct {
@@ -44,6 +48,12 @@ func init() {
 	// Global settings {{{
 	cmdline.IntVar(&Config.ConcurrentJobs, "j", 2, "Number of concurrent jobs")
 	cmdline.StringVar(&Config.LibraryDir, "library_dir", ".", "Search speeldoos files in this directory")
+
+	// }}}
+	// External tools {{{
+	cmdline.StringVar(&Config.Tools.Flac, "tools.flac", "", "Path to `flac`")
+	cmdline.StringVar(&Config.Tools.Metaflac, "tools.metaflac", "", "Path to `metaflac`")
+	cmdline.StringVar(&Config.Tools.Lame, "tools.lame", "", "Path to `lame`")
 
 	// }}}
 	// Settings for `sd extract` {{{
@@ -120,6 +130,16 @@ func init() {
 	}
 
 	// Sanity checks
+
+	if Config.Tools.Flac == "" {
+		Config.Tools.Flac = "flac"
+	}
+	if Config.Tools.Metaflac == "" {
+		Config.Tools.Metaflac = "metaflac"
+	}
+	if Config.Tools.Lame == "" {
+		Config.Tools.Lame = "lame"
+	}
 
 	if Config.ConcurrentJobs < 1 {
 		Config.ConcurrentJobs = 1

--- a/cmd/speeldoos/speeldoos.go
+++ b/cmd/speeldoos/speeldoos.go
@@ -16,6 +16,7 @@ var Config = struct {
 	Tools          struct {
 		Flac, Metaflac string
 		Lame           string
+		ID3v2          string
 	}
 	Extract struct {
 		Bitrate string
@@ -54,6 +55,7 @@ func init() {
 	cmdline.StringVar(&Config.Tools.Flac, "tools.flac", "", "Path to `flac`")
 	cmdline.StringVar(&Config.Tools.Metaflac, "tools.metaflac", "", "Path to `metaflac`")
 	cmdline.StringVar(&Config.Tools.Lame, "tools.lame", "", "Path to `lame`")
+	cmdline.StringVar(&Config.Tools.ID3v2, "tools.id3v2", "", "Path to `id3v2`")
 
 	// }}}
 	// Settings for `sd extract` {{{
@@ -139,6 +141,9 @@ func init() {
 	}
 	if Config.Tools.Lame == "" {
 		Config.Tools.Lame = "lame"
+	}
+	if Config.Tools.ID3v2 == "" {
+		Config.Tools.ID3v2 = "id3v2"
 	}
 
 	if Config.ConcurrentJobs < 1 {


### PR DESCRIPTION
Sadly, not everyone uses linux. Let's make sure it works for those poor souls too.

Ideally, I'd still shell out to `flac.exe`, `lame.exe` and/or `lame.exe` and possibly bundle those in the same download. I'd need some autodetection or configurability, the latter of which makes more sense to do after combining all subcommands into one executable (PR #3).

Also, to my knowledge there's no standardized `mktorrent` utility for Windows.